### PR TITLE
Support `force encryption` for the MSSQL server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     name: Tests
     strategy:
       matrix:
+        force-encryption:
+          - "true"
+          - "false"
         os:
           # ignore ARM64 flavours
           - ubuntu-20.04
@@ -22,7 +25,12 @@ jobs:
         version:
           - 2017
         exclude:
-          - os: ubuntu-24.04
+          - force-encryption: "true"
+            os: ubuntu-24.04
+            version: 2017
+
+          - force-encryption: "false"
+            os: ubuntu-24.04
             version: 2017
 
     runs-on: ${{ matrix.os }}
@@ -39,6 +47,7 @@ jobs:
         uses: ./action
         with:
           components: sqlcmd,sqlengine
+          force-encryption: ${{ matrix.force-encryption }}
           sa-password: "bHuZH81%cGC6"
           version: ${{ matrix.version }}
 
@@ -47,4 +56,5 @@ jobs:
           action/test.ps1
         shell: pwsh
         env:
+          FORCE_ENCRYPTION: ${{ matrix.force-encryption }}
           SA_PASSWORD: "bHuZH81%cGC6"

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
   components:
     description: "The components to install"
     required: true
+  force-encryption:
+    description: "Should the server force encryption?"
+    required: false
+    default: "false"
   sa-password:
     description: "The SA password for the SQL instance"
     required: true
@@ -20,6 +24,7 @@ runs:
       run: |
         $params = @{
             Components = ("${{ inputs.components }}" -split ",").Trim()
+            ForceEncryption = "${{ inputs.force-encryption }}" -eq "true"
             SaPassword = "${{ inputs.sa-password }}"
             Version = "${{ inputs.version }}"
         }

--- a/test.ps1
+++ b/test.ps1
@@ -8,3 +8,34 @@ else {
 
 Write-Output "Checking if SQL Server is available ..."
 & sqlcmd -S 127.0.0.1 -U sa -P $env:SA_PASSWORD -Q "SELECT 1"
+
+Write-Output "Check status of connection encryption ..."
+
+$sqlQuery = @"
+SELECT 
+session_id,
+encrypt_option
+FROM sys.dm_exec_connections
+WHERE session_id = @@SPID;
+"@
+
+$results = sqlcmd -S 127.0.0.1 -U sa -P $env:SA_PASSWORD -Q $sqlQuery -h -1 -W
+
+if ($env:FORCE_ENCRYPTION -eq "true") {
+    if ($results -match "TRUE") {
+        Write-Output "Connection from sqlcmd to the sqlengine appears to be encrypted, as expected!"
+    }
+    else {
+        Write-Error "Connection to SQL server is not encrypted!"
+        exit 1
+    }
+}
+else {
+    if ($results -match "TRUE") {
+        Write-Error "Somehow the connection to the SQL server is encrypted, misconfiguration?"
+        exit 1
+    }
+    else {
+        Write-Output "Connection from sqlcmd to the sqlengine appears to not be encrypted, as expected!"
+    }
+}


### PR DESCRIPTION
Closes #4 

This is a small feature I'd like to have for `tiny_tds`: as we compile OpenSSL for FreeTDS in our distribution there, I would like to make sure that encrypted connections to the MSSQL server will work, even when we update the software.